### PR TITLE
fix(requirements.txt): bump jinja2 version to 3.1.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-jinja2==2.11.3
+jinja2==3.1.2
 bitstring==3.1.9
 scapy==2.4.5
 prettytable==3.3.0


### PR DESCRIPTION
make jinja compatable with markupsafe package

fix #15